### PR TITLE
カスタムセクション機能の追加

### DIFF
--- a/lua/neo-slack/init.lua
+++ b/lua/neo-slack/init.lua
@@ -103,6 +103,14 @@ function M.setup(opts)
   local starred_channels = storage.load_starred_channels()
   state.set_starred_channels(starred_channels)
   
+  -- カスタムセクションの情報を読み込み
+  local custom_sections = storage.load_custom_sections()
+  state.custom_sections = custom_sections
+  
+  -- チャンネルとセクションの関連付けを読み込み
+  local channel_section_map = storage.load_channel_section_map()
+  state.channel_section_map = channel_section_map
+  
   -- セクションの折りたたみ状態を初期化
   state.init_section_collapsed()
   

--- a/lua/neo-slack/storage.lua
+++ b/lua/neo-slack/storage.lua
@@ -13,6 +13,8 @@ M.storage_dir = vim.fn.stdpath('data') .. '/neo-slack'
 M.token_file = M.storage_dir .. '/token'
 M.starred_channels_file = M.storage_dir .. '/starred_channels'
 M.section_collapsed_file = M.storage_dir .. '/section_collapsed'
+M.custom_sections_file = M.storage_dir .. '/custom_sections'
+M.channel_section_map_file = M.storage_dir .. '/channel_section_map'
 
 -- ストレージディレクトリを初期化
 ---@return boolean 初期化に成功したかどうか
@@ -189,6 +191,106 @@ function M.load_section_collapsed()
   file:close()
   
   return section_collapsed
+end
+
+-- カスタムセクションを保存
+---@param custom_sections table カスタムセクションのテーブル
+---@return boolean 保存に成功したかどうか
+function M.save_custom_sections(custom_sections)
+  if not M.init() then
+    return false
+  end
+  
+  local file = io.open(M.custom_sections_file, 'w')
+  if not file then
+    utils.notify('カスタムセクションの保存に失敗しました', vim.log.levels.ERROR)
+    return false
+  end
+  
+  -- JSONに変換して保存
+  local json_str = vim.fn.json_encode(custom_sections)
+  file:write(json_str)
+  file:close()
+  
+  return true
+end
+
+-- カスタムセクションを読み込み
+---@return table カスタムセクションのテーブル
+function M.load_custom_sections()
+  local custom_sections = {}
+  
+  if vim.fn.filereadable(M.custom_sections_file) == 0 then
+    return custom_sections
+  end
+  
+  local file = io.open(M.custom_sections_file, 'r')
+  if not file then
+    utils.notify('カスタムセクションファイルの読み込みに失敗しました', vim.log.levels.ERROR)
+    return custom_sections
+  end
+  
+  local content = file:read('*all')
+  file:close()
+  
+  if content and content ~= '' then
+    local ok, decoded = pcall(vim.fn.json_decode, content)
+    if ok and decoded then
+      custom_sections = decoded
+    end
+  end
+  
+  return custom_sections
+end
+
+-- チャンネルとセクションの関連付けを保存
+---@param channel_section_map table チャンネルとセクションの関連付けテーブル
+---@return boolean 保存に成功したかどうか
+function M.save_channel_section_map(channel_section_map)
+  if not M.init() then
+    return false
+  end
+  
+  local file = io.open(M.channel_section_map_file, 'w')
+  if not file then
+    utils.notify('チャンネルとセクションの関連付けの保存に失敗しました', vim.log.levels.ERROR)
+    return false
+  end
+  
+  -- JSONに変換して保存
+  local json_str = vim.fn.json_encode(channel_section_map)
+  file:write(json_str)
+  file:close()
+  
+  return true
+end
+
+-- チャンネルとセクションの関連付けを読み込み
+---@return table チャンネルとセクションの関連付けテーブル
+function M.load_channel_section_map()
+  local channel_section_map = {}
+  
+  if vim.fn.filereadable(M.channel_section_map_file) == 0 then
+    return channel_section_map
+  end
+  
+  local file = io.open(M.channel_section_map_file, 'r')
+  if not file then
+    utils.notify('チャンネルとセクションの関連付けファイルの読み込みに失敗しました', vim.log.levels.ERROR)
+    return channel_section_map
+  end
+  
+  local content = file:read('*all')
+  file:close()
+  
+  if content and content ~= '' then
+    local ok, decoded = pcall(vim.fn.json_decode, content)
+    if ok and decoded then
+      channel_section_map = decoded
+    end
+  end
+  
+  return channel_section_map
 end
 
 return M


### PR DESCRIPTION
## 変更内容

Slack Appのようなカスタムセクション機能を実装しました。この機能により、ユーザーは自由にセクションを作成し、チャンネルをグループ化できるようになります。

### 主な変更点

1. **データモデル**
   - カスタムセクションのリストを保存するテーブルを追加
   - チャンネルとセクションの関連付けを管理する機能を追加

2. **永続化**
   - カスタムセクションの保存・読み込み機能を追加
   - チャンネルとセクションの関連付けの保存・読み込み機能を追加

3. **UI**
   - セクション作成・編集・削除のダイアログ機能を追加
   - チャンネルをセクションに割り当てる機能を追加
   - チャンネル一覧表示をカスタムセクション対応に修正

4. **キーマッピング**
   - `c`: 新しいセクションを作成
   - `e`: セクションを編集
   - `d`: セクションを削除
   - `a`: チャンネルをセクションに割り当て

この実装により、多くのチャンネルがある場合でも、ユーザーが自分でセクションを作成してチャンネルをグループ化できるようになり、UIの使いやすさが向上します。