### PR TITLE
スレッド返信にもメッセージ一覧と同様の色付けを適用

### DIFF
--- a/lua/neo-slack/ui.lua
+++ b/lua/neo-slack/ui.lua
@@ -719,7 +719,7 @@ function M.show_thread_replies(thread_ts, replies, parent_message)
   M.layout.thread_buf = bufnr
   
   -- バッファを設定
-  setup_buffer_options(bufnr, 'neo-slack-thread')
+  setup_buffer_options(bufnr, 'neo-slack-messages')
   
   -- スレッド一覧を整形
   local lines = {


### PR DESCRIPTION
## 変更内容
スレッド返信でもメッセージ一覧と同様にユーザー名などに色が付くように修正しました。

## 問題の原因
スレッド一覧のバッファに設定されていたファイルタイプ（neo-slack-thread）に対応するシンタックスハイライト定義が存在しなかったため。

## 解決策
スレッド一覧のバッファにもneo-slack-messagesというファイルタイプを設定することで、同じシンタックスハイライトを適用するようにしました。